### PR TITLE
Update EppClientMarshallerHelper.java

### DIFF
--- a/src/main/java/cz/active24/client/fred/eppclient/EppClientMarshallerHelper.java
+++ b/src/main/java/cz/active24/client/fred/eppclient/EppClientMarshallerHelper.java
@@ -172,6 +172,6 @@ public class EppClientMarshallerHelper {
                 cz.nic.xml.epp.fredcom_1.ObjectFactory.class,
                 cz.nic.xml.epp.auction_1.ObjectFactory.class,
                 ietf.params.xml.ns.eppcom_1.ObjectFactory.class
-        ).toArray();
+        ).toArray(new Class[0]); // <-- THE FIX IS APPLIED HERE  
     }
 }


### PR DESCRIPTION
 // =================================================================================================
    // FIX for Java 11+ Compatibility
    //
    // REASON FOR CHANGE:
    // The original implementation of this method causes a `java.lang.ClassCastException` when running
    // on modern JDKs (Java 11 and newer).
    //
    // ROOT CAUSE:
    // The call to `.toArray()` on a List, without a typed array argument, returns a generic `Object[]`.
    // The subsequent attempt to cast this `Object[]` to a `Class[]` fails at runtime due to stricter
    // type checking in modern Java versions.
    //
    // SOLUTION:
    // The fix is to use the overloaded method `.toArray(new Class[0])`. This is the type-safe way
    // to convert the list into a `Class[]` array, as it informs the JVM of the desired output type.
    //
    // OUTCOME:
    // This change resolves the runtime exception and allows the application to run correctly on
    // Java 11+ environments, making the library compatible with modern infrastructure.
    // =================================================================================================